### PR TITLE
fix(protection): improve PR merge detection

### DIFF
--- a/.github/workflows/block_pr_into_dev_main.yaml
+++ b/.github/workflows/block_pr_into_dev_main.yaml
@@ -9,17 +9,20 @@ jobs:
   check-branch:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if push is from PR merge
-        if: github.event.head_commit.message != null && startsWith(github.event.head_commit.message, 'merge:')
-        run: |
-          echo "✅ Merge commit detected, allowing the push"
-          exit 0
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
-      - name: Block direct push
-        if: ${{ !github.event.pull_request }}
+      - name: Check push type
         run: |
-          # Se não for um merge commit e não for um PR, bloqueia
-          if [[ "${{ github.event.head_commit.message }}" != *"merge:"* ]]; then
+          IS_MERGE=$(git log -1 --pretty=%P ${{ github.sha }} | wc -w)
+
+          COMMIT_MSG=$(git log -1 --pretty=%B ${{ github.sha }})
+
+          if [[ "$IS_MERGE" == "2" ]] || [[ "$COMMIT_MSG" =~ ^merge: ]] || [[ "${{ github.event.ref }}" == "refs/heads/dev" && "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "✅ Merge commit or PR merge detected, allowing the push"
+            exit 0
+          else
             echo "❌ Direct push to protected branches is not allowed!"
             echo "Please create a Pull Request to update these branches."
             exit 1


### PR DESCRIPTION
### Changes Made
- Fixed false positive blocking of PR merges
- Added better merge commit detection logic
- Improved branch protection validation
- Fixed dev branch PR merge handling

### Problem
PR merges into dev were being incorrectly blocked by the branch protection

### Solution
- Added proper merge commit detection using git parent count
- Added checks for PR merge events
- Added support for merge: prefix messages

 