### PR TITLE
fix: update deployment scripts to use bash for executing scripts 

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -175,13 +175,13 @@ jobs:
             chmod +x install-services.sh &&
             if ! command -v docker &> /dev/null || ! command -v docker compose &> /dev/null; then
               echo 'Installing Docker and dependencies...'
-              sudo ./install-services.sh
+              bash ./install-services.sh
             else
               echo 'Docker and dependencies already installed'
             fi
           "
          
-      - name: Set Execute Permissions
+      - name: Set Execute Permissions and Verify
         env:
           SSH_USER: ${{ secrets.SSH_USERNAME }}
           SSH_HOST: ${{ secrets.SSH_HOST }}
@@ -189,7 +189,11 @@ jobs:
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST "
             cd ~/onforkhub-deploy &&
             chmod +x *.sh &&
-            ls -la
+            echo 'Permissions set, verifying:' &&
+            ls -la *.sh &&
+            echo 'Testing executability:' &&
+            test -x cleanup-services.sh && echo '✅ cleanup-services.sh is executable' || echo '❌ cleanup-services.sh is NOT executable' &&
+            test -x start-services.sh && echo '✅ start-services.sh is executable' || echo '❌ start-services.sh is NOT executable'
           "
          
       - name: Deploy Services
@@ -201,10 +205,10 @@ jobs:
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST "
             cd ~/onforkhub-deploy &&
             echo 'Starting cleanup...' &&
-            ./cleanup-services.sh &&
+            bash ./cleanup-services.sh &&
             echo 'Starting services in ${{ github.ref_name == 'main' && 'PRODUCTION' || 'DEVELOPMENT' }} environment...' &&
             export ASPNETCORE_ENVIRONMENT=${{ github.ref_name == 'main' && 'Production' || 'Development' }} &&
-            ./start-services.sh '${{ secrets.CONTAINER_REGISTRY_TOKEN }}' '${{ github.actor }}'
+            bash ./start-services.sh '${{ secrets.CONTAINER_REGISTRY_TOKEN }}' '${{ github.actor }}'
           "
          
       - name: Verify Deployment Status
@@ -238,7 +242,7 @@ jobs:
           ssh -i ~/.ssh/deploy_key $SSH_USER@$SSH_HOST "
             cd ~/onforkhub-deploy &&
             echo 'Deployment failed, cleaning up...' &&
-            ./cleanup-services.sh
+            bash ./cleanup-services.sh
           "
 
       - name: Notify Deployment Status


### PR DESCRIPTION
This pull request updates the `.github/workflows/build-and-deploy.yml` file to enhance script execution reliability and improve verification during deployment processes. The most important changes involve switching from `./script.sh` to `bash ./script.sh` for script execution and adding verification steps to ensure scripts have proper permissions and are executable.

### Script Execution Enhancements:
* Updated all script executions (`install-services.sh`, `cleanup-services.sh`, `start-services.sh`) to use `bash ./script.sh` instead of `./script.sh` for improved compatibility and error handling. [[1]](diffhunk://#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33L178-R196) [[2]](diffhunk://#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33L204-R211) [[3]](diffhunk://#diff-ecad2183af1362d9d99f4a33e7491c1970c92255c3c318e688ece549ec91fe33L241-R245)

### Verification Improvements:
* Enhanced the "Set Execute Permissions" step by adding checks to verify that scripts (`cleanup-services.sh`, `start-services.sh`) are executable, with clear success (`✅`) or failure (`❌`) messages.…enhance permission verification